### PR TITLE
edit README, and migration updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Current play stack
 ### Install [rbenv](https://github.com/sstephenson/rbenv)
 
 ```bash
-git clone git@github.com:brancusi/lingo.git
+git clone git@github.com:brancusi/lingo-server.git
 
-cd lingo/server
+cd lingo-server
 
 bundle
 
-rake db:migrate
+rake db:create db:migrate
 ```
 
 ### Signup for a trial account at [talkbox](http://tokbox.com)
@@ -28,7 +28,6 @@ Setup your local environment variables
 ```bash
 cp .env_template .env
 ```
-
 ### Open the project in your favorite editor
 
 Edit the .env file with your credentials found in your opentalk dashboard
@@ -44,6 +43,8 @@ rails s
 ```
 
 ## Setup client
+
+Go [https://github.com/brancusi/lingo-client](https://github.com/brancusi/lingo-client) for more details
 
 ### Install [ember-cli](http://www.ember-cli.com/)
 ```bash

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,9 @@
 
 ActiveRecord::Schema.define(version: 20150929225332) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "open_talk_sessions", force: :cascade do |t|
     t.string   "name"
     t.string   "session_id"
@@ -23,6 +26,7 @@ ActiveRecord::Schema.define(version: 20150929225332) do
   create_table "users", force: :cascade do |t|
     t.string   "email"
     t.string   "token"
+    t.string   "ot_token"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
maybe @brancusi makes change on README soon that there's another repo for client? It's a small thing, for postgres database in development, it would be nicer when we add a line `rake db:create` before `rake db:migrate`
